### PR TITLE
Update admin user pipa with new password

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Python has the libraries pre-installed.
   
   -Pillow
 
-The pipa admin user is active and you have to create the key in sign up after login again to be able to access with the key created within the jupyterhub you can manage new users and give them access
+The pipa admin user is active and you have to create the key in sign up after login again to be able to access with the key created within the jupyterhub you can manage new users and give them access. The password for the pipa admin user is `Pipa14!`.
 
 ## Running JupyterHub with Docker Compose
 

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -7,6 +7,8 @@ c.JupyterHub.authenticator_class = 'nativeauthenticator.NativeAuthenticator'
 
 c.Authenticator.admin_users = {'pipa'}
 
+c.Authenticator.admin_users = {'pipa': 'Pipa14!'}
+
 # The pre_spawn_hook function is used to create a new user on the system if it does not already exist.
 def pre_spawn_hook(spawner):
 


### PR DESCRIPTION
Add password for admin user `pipa` in `jupyterhub_config.py` and update `README.md`.

* **jupyterhub_config.py**
  - Add `c.Authenticator.admin_users` entry for user `pipa` with password `Pipa14!`.

* **README.md**
  - Update the section about the pipa admin user to include the new password `Pipa14!`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SDanker/Jupyter-Hub/pull/4?shareId=8482d1cd-b790-4ff1-8673-adaff3d49e67).