### PR TITLE
Add Julia support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ FROM jupyterhub/jupyterhub:latest
 # Install Python packages
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y nodejs npm git nano r-base libzmq3-dev libcurl4-openssl-dev libssl-dev jupyter-core jupyter-client && \
+    apt-get install -y nodejs npm git nano r-base libzmq3-dev libcurl4-openssl-dev libssl-dev julia jupyter-core jupyter-client && \
     git clone https://github.com/jupyterhub/configurable-http-proxy /configurable-http-proxy && \
     python3 -m pip install notebook jupyterlab && \
     pip install --upgrade pip && \
     pip install jupyterhub-nativeauthenticator && \
     R -e "install.packages(c('repr', 'IRdisplay', 'IRkernel'), type = 'source')" && \
     R -e "IRkernel::installspec(user = FALSE)" && \
+    julia -e "using Pkg; Pkg.add('IJulia')" && \
     pip install geopandas numpy seaborn pandas tensorflow scipy matplotlib keras scikit-learn Scrapy3 opencv-python openpyxl Theano beautifulsoup4 peewee Pillow gensim nltk
 
 COPY jupyterhub_config.py /srv/jupyterhub/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jupyter-Hub
 Docker with Jupyterhub to have multiple users.
-Consists with Python and R
+Consists with Python, R and Julia
 
 Python has the libraries pre-installed.
   
@@ -33,8 +33,10 @@ Python has the libraries pre-installed.
   -beautifulsoup4
   
   -Pee Wee
-  
+
   -Pillow
+
+Julia includes the IJulia kernel pre-installed for running Julia notebooks.
 
 The pipa admin user is active and you have to create the key in sign up after login again to be able to access with the key created within the jupyterhub you can manage new users and give them access
 


### PR DESCRIPTION
## Summary
- add Julia to installation and install IJulia kernel
- document Julia support in the README

## Testing
- `python -m py_compile jupyterhub_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6841d2f425f883308eba8b6087f3ec3a